### PR TITLE
feat: プロジェクト向けのeditorconfigの設定を追加

### DIFF
--- a/bases/editorconfig/.editorconfig
+++ b/bases/editorconfig/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+# Default
+indent_style = space
+indent_size = 2
+
+# Custom
+# [*.yaml]
+# indent_style = tab
+# indent_size = 4

--- a/bases/editorconfig/README.md
+++ b/bases/editorconfig/README.md
@@ -1,0 +1,8 @@
+# editorconfig
+
+## install
+
+1. コンフィグを配置する
+   - プロジェクトルートに`.editorconfig`を配置してください
+2. エディタ、IDEの設定を有効にしてください
+   - [vscode](../vscode/sample.code-workspace)ではデフォルトで有効です


### PR DESCRIPTION
基本的な`editorconfig`を追加しました。
tabでインデントが求められるプロジェクト、もしくは拡張子がある場合はプロジェクト単位で設定する前提です。
一般的なファイルで上記のような制限がある場合は、都度追加していければいいのかなと考えています

