### PR TITLE
chore: dependabot の config に `typescript-eslint` の group を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,8 @@ updates:
       interval: monthly
       day: monday
     open-pull-requests-limit: 5
-
-  # bases 内の依存を更新するための設定
-  # - package-ecosystem: npm
-  #   directories:
-  #     - bases/foo/bar # ここに対象ディレクトリを列挙
-  #   schedule:
-  #     interval: monthly
-  #     day: monday
-  #   open-pull-requests-limit: 5
-
+    groups:
+      typescript-eslint:
+        patterns:
+          - "typescript-eslint"
+          - "@typescript-eslint/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
       day: monday
     open-pull-requests-limit: 5
     groups:


### PR DESCRIPTION

- 以下のパッケージの更新を1つにまとめるように `typescript-eslint` group を作成
  - `typescript-eslint`
  - `@typescript-eslint/*`
- 更新頻度が monthly の月曜になっていたので、weekly に変更 
